### PR TITLE
Avoid calling remove when _modal isn't defined.

### DIFF
--- a/src/js/slider.js
+++ b/src/js/slider.js
@@ -168,6 +168,7 @@
       };
 
       scope.$on('$destroy', function() {
+        if (!_modal) return;
         _modal.remove();
       });
       


### PR DESCRIPTION
Not sure if this is the best way to handle this, or if it's possible to not enable this scope in the first place when you haven't clicked on an image.  Thoughts?  Thanks for your work!!!
