### PR TITLE
Add config option to allow fixed row size

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ app.config(function(ionGalleryConfigProvider) {
   ionGalleryConfigProvider.setGalleryConfig({
                           action_label: 'Close',
                           toggle: false,
-                          row_size: 3
+                          row_size: 3,
+                          fixed_row_size: false
   });
 });
 ```
@@ -71,7 +72,8 @@ app.config(function(ionGalleryConfigProvider) {
 Default values
 action_label - 'Close' (String)
 toggle - false (Boolean)
-row_zie - 3 (Int)
+row_size - 3 (Int)
+fixed_row_size - false (boolean). If true, thumbnails in gallery will always be sized as if there are "row_size" number of images in a row (even if there aren't).
 ```
 
 - Via markup:

--- a/dist/ion-gallery.js
+++ b/dist/ion-gallery.js
@@ -23,7 +23,12 @@
 
     function controller($scope) {
       var _drawGallery = function () {
-        $scope.ionGalleryRowSize = ionGalleryHelper.getRowSize(parseInt($scope.ionGalleryRowSize) || ionGalleryConfig.row_size, $scope.ionGalleryItems.length);
+        if (ionGalleryConfig.fixed_row_size) {
+          $scope.ionGalleryRowSize = parseInt($scope.ionGalleryRowSize) || ionGalleryConfig.row_size;
+        }
+        else {
+          $scope.ionGalleryRowSize = ionGalleryHelper.getRowSize(parseInt($scope.ionGalleryRowSize) || ionGalleryConfig.row_size, $scope.ionGalleryItems.length);
+        }
         $scope.actionLabel = ionGalleryConfig.action_label;
         $scope.items = ionGalleryHelper.buildGallery($scope.ionGalleryItems, $scope.ionGalleryRowSize);
         $scope.responsiveGrid = parseInt((1 / $scope.ionGalleryRowSize) * 100);
@@ -60,7 +65,8 @@
     this.config = {
       action_label: 'Done',
       toggle: true,
-      row_size: 3
+      row_size: 3,
+      fixed_row_size: false
     };
 
     this.$get = function() {


### PR DESCRIPTION
Add a configuration option to allow a fixed row size for gallery thumbnails. If this option is "true", then thumbnails in the gallery will always be sized as if there are "row_size" number of images in the row. If "false", thumbnail sizing behaves "normally" (which still has kinks to iron out, see issue https://github.com/pedroabreu/ion-gallery/issues/30). 
